### PR TITLE
repo.py: fix 'None' in mbox apply warning

### DIFF
--- a/lib/repo.py
+++ b/lib/repo.py
@@ -290,8 +290,8 @@ class Repo(object):
             try:
                 cmd = None
                 if self._mbox:
-                    self._check_apply(mbox=item)
                     msg = "The mbox %s" % item
+                    self._check_apply(mbox=item)
                     cmd = {'cmd':['git', 'am', item]}
                 elif self._series_revision:
                     msg = "The series/revision %s/%s" % item


### PR DESCRIPTION
When an mbox fails to apply, a warning is raised/logged informing
of this. The message for this warning needs to be set before
check_apply is called.

Signed-off-by: Alex Franco <alejandro.franco@linux.intel.com>